### PR TITLE
Storing secrets using environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Pipfile.lock
 __pycache__/
 .idea/
 .cache
+.env

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ verify_ssl = true
 
 [dev-packages]
 pylint = "*"
+black = "*"
 
 [packages]
 requests = "*"
@@ -12,3 +13,6 @@ spotipy = "*"
 
 [requires]
 python_version = "3.8"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ black = "*"
 [packages]
 requests = "*"
 spotipy = "*"
+python-dotenv = "*"
 
 [requires]
 python_version = "3.8"

--- a/log_in.py
+++ b/log_in.py
@@ -1,14 +1,22 @@
+""" Using authorization code flow so that we can access user information.
+To keep secrets out of the code, they should be set as environment variables.
+Spotipy uses three environment variables for authentication with authorization code flow:
+* SPOTIPY_CLIENT_ID
+* SPOTIPY_CLIENT_SECRET
+* SPOTIPY_REDIRECT_URI
+"""
+import os
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
-from CLIENT_SECRET import CLIENT_SECRET
 
-scopes = "playlist-modify-public playlist-modify-private playlist-read-private playlist-read-collaborative"
 
-def get_Oauth(scope):
-    redirect_url = "http://127.0.0.1:9090"
-    # client
-    Spotify_Oauth = SpotifyOAuth(client_id=CLIENT_ID,client_secret=CLIENT_SECRET,redirect_uri=redirect_url,scope=scope)
-    return Spotify_Oauth
-
-sp = spotipy.Spotify(auth_manager=get_Oauth(scope=scopes))
-
+def log_in():
+    # The permissions we want to request from Spotify
+    scopes = (
+        "playlist-modify-public"
+        "playlist-modify-private"
+        "playlist-read-private"
+        "playlist-read-collaborative"
+    )
+    sp_session = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scopes))
+    return sp_session

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
-# log in
 # Create TeamGroove user DB
+from dotenv import load_dotenv
+from log_in import log_in
 
 
 """options"""
@@ -10,10 +11,14 @@
 """Create new Teamgroove playlist"""
 # List trough current users colab playlists
 # Check playlist ID against TeamGroove playlists
-    # if already in use, suggest joining it.
+# if already in use, suggest joining it.
 # Create Teamgroove playlist database
 
 
-from log_in import sp
+def main():
+    load_dotenv()
+    log_in()
 
 
+if __name__ == "__main__":
+    main()

--- a/spotify_api_test.py
+++ b/spotify_api_test.py
@@ -4,7 +4,10 @@
 #	Reorder a Playlist's Items
 import requests
 import json
+from dotenv import load_dotenv
 
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
 
 def get_playlists():
     # token needed here
@@ -32,6 +35,14 @@ def get_playlist_id(user_choice):
     # print(f"playlist id {playlist['id']}")
     print(f"Chosen playlist = {playlist['name']}")
 
+load_dotenv()
 
-get_playlist_names()
-get_playlist_id(input("Choose number"))
+scope = "user-library-read"
+
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
+b_jaxx_urn = "https://open.spotify.com/artist/4YrKBkKSVeqDamzBPWVnSJ"
+artist = sp.artist(b_jaxx_urn)
+print(artist)
+
+# get_playlist_names()
+# get_playlist_id(input("Choose number"))

--- a/spotify_authorization_code_flow.py
+++ b/spotify_authorization_code_flow.py
@@ -1,0 +1,23 @@
+""" Authorization Code Flow
+
+This flow is suitable for long-running applications in which the user grants permission only once.
+It provides an access token that can be refreshed. Since the token exchange involves sending your
+secret key, perform this on a secure location, like a backend service, and not from a client such
+as a browser or from a mobile app.
+https://spotipy.readthedocs.io/en/2.16.1/#authorization-code-flow"""
+
+from dotenv import load_dotenv
+
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+
+load_dotenv()
+
+scope = "user-library-read"
+
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
+
+results = sp.current_user_saved_tracks()
+for idx, item in enumerate(results["items"]):
+    track = item["track"]
+    print(idx, track["artists"][0]["name"], " – ", track["name"])

--- a/spotify_client_credentials_flow.py
+++ b/spotify_client_credentials_flow.py
@@ -1,0 +1,28 @@
+""" Client Credentials Flow
+
+The Client Credentials flow is used in server-to-server authentication. Only endpoints that do not
+access user information can be accessed. The advantage here in comparison with requests to the Web
+API made without an access token, is that a higher rate limit is applied.
+https://spotipy.readthedocs.io/en/2.16.1/#client-credentials-flow"""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import spotipy
+from spotipy.oauth2 import SpotifyClientCredentials
+
+auth_manager = SpotifyClientCredentials()
+sp = spotipy.Spotify(auth_manager=auth_manager)
+
+playlists = sp.user_playlists("spotify")
+while playlists:
+    for i, playlist in enumerate(playlists["items"]):
+        print(
+            "%4d %s %s"
+            % (i + 1 + playlists["offset"], playlist["uri"], playlist["name"])
+        )
+    if playlists["next"]:
+        playlists = sp.next(playlists)
+    else:
+        playlists = None


### PR DESCRIPTION
The Spotify API requires a client ID and client secret which cannot be securely stored in the code. This change has the ID and secret stored as environment variables that can be set up for production environments. For development and local environments, the ID and secret can be stored in a .env file that is not stored in the source code repository.