### PR TITLE
Authorizing team groove to access spotify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ workspace.xml
 # Poetry
 poetry.lock
 
+# Stop your Spotify Token getting copied to git
+.spotify_caches/

--- a/grooveboard/views.py
+++ b/grooveboard/views.py
@@ -1,12 +1,17 @@
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, reverse
 from django.contrib.auth.decorators import login_required
 
 from room.models import Room, Invitation
+
 
 @login_required
 def grooveboard(request):
     rooms = request.user.rooms.exclude(pk=request.user.active_room_id)
     invitations = Invitation.objects.filter(email=request.user.email, status=Invitation.INVITED)
+    
+    if request.GET.get("code"):
+        spotify_code = request.GET.get("code")
+        return redirect('authorize_with_spotify', spotify_code=spotify_code)
 
     if invitations:
         return redirect('accept_invitation')

--- a/spotify/views.py
+++ b/spotify/views.py
@@ -1,3 +1,40 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.contrib.auth.decorators import login_required
 
-# Create your views here.
+import spotipy
+import os
+
+
+caches_folder = './.spotify_caches/'
+if not os.path.exists(caches_folder):
+    os.makedirs(caches_folder)
+
+def session_cache_path(request):
+    return caches_folder + request.user.email
+
+@login_required
+def authorize_with_spotify(request, spotify_code=None):
+    cache_handler = spotipy.cache_handler.CacheFileHandler(cache_path=session_cache_path(request))
+    auth_manager = spotipy.oauth2.SpotifyOAuth(scope='playlist-read-private',
+                                                cache_handler=cache_handler,
+                                                show_dialog=True)
+
+    # If we have a code from Spotify then grab the autho token and refresh token and bung in .spotify_caches directory.
+    if spotify_code:        
+        auth_manager.get_access_token(spotify_code)
+        # once we have a token we can then do stuff
+        spotify = spotipy.Spotify(auth_manager=auth_manager)        
+    
+    # Do we have an autho token? No - then off we go to Spotify to get a code so we can get one.
+    if not auth_manager.validate_token(cache_handler.get_cached_token()):
+        auth_url = auth_manager.get_authorize_url()
+        return redirect(auth_url)
+    
+    spotify = spotipy.Spotify(auth_manager=auth_manager)
+    current_user_playlists = spotify.current_user_playlists()
+    
+    context = {
+        'current_user_playlists': current_user_playlists
+    }
+
+    return render(request, 'user_playlists.html', context)

--- a/team_groove/templates/room.html
+++ b/team_groove/templates/room.html
@@ -62,7 +62,7 @@
             <hr>
             {% if active_room.created_by == request.user %}
                 <a href="{% url 'invite' %}" class="btn btn-secondary btn-block"><i class="fa fa-envelope" aria-hidden="true"></i> Invite Groovers to Join Your Room</a>
-                <a href="#" class="btn btn-success btn-block"><i class="fa fa-envelope" aria-hidden="true"></i> Create a Playlist for Your Room</a>
+                <a href="{% url 'authorize_with_spotify' %}" class="btn btn-success btn-block"><i class="fa fa-envelope" aria-hidden="true"></i> View Your Spotify Playlists</a>
             {% endif %}
         </div>
 {% endif %}

--- a/team_groove/templates/user_playlists.html
+++ b/team_groove/templates/user_playlists.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block title %}Playlists | {% endblock %}
+
+{% block content %}
+<h3>Choose one of your Spotify playlists to add to your Groove room:</h3>
+
+<div class="list-group">
+    {% for playlist in current_user_playlists.items %}          
+        <a href="#" class="list-group-item list-group-item-action">{{ playlist.name }}</a>    
+    {% endfor %}
+</div>
+
+{% endblock %}

--- a/team_groove/urls.py
+++ b/team_groove/urls.py
@@ -22,6 +22,8 @@ from users.views import signup
 from grooveboard.views import grooveboard
 from room.views import add_room, activate_room, room, invite, accept_invitation, edit_room, delete_room
 
+from spotify.views import authorize_with_spotify
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', FrontPageView.as_view(), name='frontpage'),
@@ -33,6 +35,11 @@ urlpatterns = [
     path('room/edit_room/', edit_room, name='edit_room'),
     path('room/delete_room/<int:room_id>/', delete_room, name='delete_room'),
     path('room/accept_invitation/', accept_invitation, name='accept_invitation'),
+
+    path('spotify/authorize_with_spotify/<spotify_code>', authorize_with_spotify, name='authorize_with_spotify'),
+    path('spotify/authorize_with_spotify/', authorize_with_spotify, name='authorize_with_spotify'),
+    
+    
 
     path('signup/', signup, name='signup'),
     path('login/', auth_views.LoginView.as_view(template_name='login.html'), name='login'),


### PR DESCRIPTION
This is just a proof of concept to show that we can authorize the TeamGroove app to access a user's Spotify account and display their playlists. If you want to test it then you need to add the url below into the redirect URI in your Spotify developer account with the registered app: 
http://127.0.0.1:8000/grooveboard