### PR TITLE
Fix for environment variables not loading from .env file.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,22 +2,26 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from pathlib import Path
 
 
 def main():
-    """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "team_groove.settings.development")
-    if os.getenv("DJANGO_SETTINGS_MODULE"):
-        os.environ["DJANGO_SETTINGS_MODULE"] = os.getenv("DJANGO_SETTINGS_MODULE")
 
     try:
         from django.core.management import execute_from_command_line
-    except ImportError as exc:
+    except ImportError:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
-        ) from exc
+        )
+
+    # This allows easy placement of apps within the interior
+    # cookiecutter_test directory.
+    current_path = Path(__file__).parent.resolve()
+    sys.path.append(str(current_path / "cookiecutter_test"))
+
     execute_from_command_line(sys.argv)
 
 

--- a/team_groove/settings/base.py
+++ b/team_groove/settings/base.py
@@ -11,17 +11,9 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 from pathlib import Path
 
-import environ
-
 ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 # TeamGroove/
 APPS_DIR = ROOT_DIR / "team_groove"
-env = environ.Env()
-
-READ_DOT_ENV_FILE = env.bool("DJANGO_READ_DOT_ENV_FILE", default=False)
-if READ_DOT_ENV_FILE:
-    # OS environment variables take precedence over variables from .env
-    env.read_env(str(ROOT_DIR / ".env"))
 
 CACHES_FOLDER = Path("./.spotify_caches/")
 CACHES_FOLDER.mkdir(parents=True, exist_ok=True)

--- a/team_groove/settings/development.py
+++ b/team_groove/settings/development.py
@@ -1,13 +1,20 @@
 """ Set up environment variables for Team Groove applications specific to production environment"""
 import os
+import environ
 
 from .base import *
-from .base import env
 
 # GENERAL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#debug
 DEBUG = True
+
+env = environ.Env()
+
+READ_DOT_ENV_FILE = env.bool("DJANGO_READ_DOT_ENV_FILE", default=True)
+if READ_DOT_ENV_FILE:
+    # OS environment variables take precedence over variables from .env
+    env.read_env(str(ROOT_DIR / ".env"))
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = env(

--- a/team_groove/settings/production.py
+++ b/team_groove/settings/production.py
@@ -1,9 +1,17 @@
 """ Set up environment variables for Team Groove applications specific to production environment"""
 import os
+import environ
 
 from .base import *
 
 DEBUG = False
+
+env = environ.Env()
+
+READ_DOT_ENV_FILE = env.bool("DJANGO_READ_DOT_ENV_FILE", default=False)
+if READ_DOT_ENV_FILE:
+    # OS environment variables take precedence over variables from .env
+    env.read_env(str(ROOT_DIR / ".env"))
 
 ALLOWED_HOSTS = []
 


### PR DESCRIPTION
- Rework manage.py to be closer to cookiecutter version
- Move loading of .env file from base.py to development.py and production.py. Set default for loading environment variables from .env file to true in development.py and false in production.py.
