### PR TITLE
Adding CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,12 +43,13 @@ jobs:
       - checkout
       - python/install-packages:  
           pkg-manager: poetry
-      - command: |
-          export SECRET_KEY=123456
-          export DJANGO_SUPERUSER_USERNAME=tgadmin
-          export DJANGO_SUPERUSER_PASSWORD=123456
-          export DJANGO_SUPERUSER_EMAIL=tgadmin@mailinator.com
-          poetry run python3 manage.py migrate
-          poetry run python3 manage.py createsuperuser --noinput
+      - run:
+          command: |
+            export SECRET_KEY=123456
+            export DJANGO_SUPERUSER_USERNAME=tgadmin
+            export DJANGO_SUPERUSER_PASSWORD=123456
+            export DJANGO_SUPERUSER_EMAIL=tgadmin@mailinator.com
+            poetry run python3 manage.py migrate
+            poetry run python3 manage.py createsuperuser --noinput
           
      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Run tests
           # This assumes pytest is installed via the install-package step above
           command: |
-            poetry run python manage.py test || true
+            poetry run python manage.py test
   trial-run:
     docker:
       - image: cimg/python:3.8
@@ -47,6 +47,6 @@ jobs:
             export DJANGO_SUPERUSER_EMAIL=tgadmin@mailinator.com
             poetry run python3 manage.py migrate
             poetry run python3 manage.py createsuperuser --noinput
-            timeout 10 poetry run python3 manage.py runserver 8081
+            timeout --preserve-status 10 poetry run python3 manage.py runserver 8081
           
      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ workflows:
     # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
     jobs:
       - build-and-test
+      - trial-run:
+          requires: 
+            - build-and-test
+
 
 
 jobs:
@@ -32,3 +36,19 @@ jobs:
           # This assumes pytest is installed via the install-package step above
           command: |
             poetry run python manage.py test 
+  trial-run:
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - python/install-packages:  
+          pkg-manager: poetry
+      - command: |
+          export SECRET_KEY=123456
+          export DJANGO_SUPERUSER_USERNAME=tgadmin
+          export DJANGO_SUPERUSER_PASSWORD=123456
+          export DJANGO_SUPERUSER_EMAIL=tgadmin@mailinator.com
+          poetry run python3 manage.py migrate
+          poetry run python3 manage.py createsuperuser --noinput
+          
+     

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,34 @@
+version: 2.1
+
+orbs:
+  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
+  # Orb commands and jobs help you with common scripting around a language/tool
+  # so you dont have to copy and paste it everywhere.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.2
+
+workflows:
+  sample:  # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run. 
+    # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
+    jobs:
+      - build-and-test
+
+
+jobs:
+  build-and-test:
+    docker:
+      - image: cimg/python:3.8
+    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
+    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
+    # Then run your tests!
+    # CircleCI will report the results back to your VCS provider.
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: poetry
+      - run:
+          name: Run tests
+          # This assumes pytest is installed via the install-package step above
+          command: |
+            poetry run python manage.py test 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,7 @@ workflows:
     # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
     jobs:
       - build-and-test
-      - trial-run:
-          requires: 
-            - build-and-test
-
-
+      - trial-run
 
 jobs:
   build-and-test:
@@ -51,5 +47,6 @@ jobs:
             export DJANGO_SUPERUSER_EMAIL=tgadmin@mailinator.com
             poetry run python3 manage.py migrate
             poetry run python3 manage.py createsuperuser --noinput
+            timeout 10 poetry run python3 manage.py runserver 8081
           
      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           name: Run tests
           # This assumes pytest is installed via the install-package step above
           command: |
-            poetry run python manage.py test 
+            poetry run python manage.py test || true
   trial-run:
     docker:
       - image: cimg/python:3.8

--- a/team_groove/settings/base.py
+++ b/team_groove/settings/base.py
@@ -11,8 +11,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 from pathlib import Path
 
-ROOT_DIR = 
-Path(__file__).resolve(strict=True).parent.parent.parent
+ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 # TeamGroove/
 APPS_DIR = ROOT_DIR / "team_groove"
 

--- a/team_groove/settings/base.py
+++ b/team_groove/settings/base.py
@@ -11,7 +11,8 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 from pathlib import Path
 
-ROOT_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
+ROOT_DIR = 
+Path(__file__).resolve(strict=True).parent.parent.parent
 # TeamGroove/
 APPS_DIR = ROOT_DIR / "team_groove"
 


### PR DESCRIPTION
This was our first attempt at producing a continuous integration for TeamGroove. We are using [CircleCI](https://circleci.com) for this. This workflow has two jobs, which run independently on containers. The first job runs the Django tests. The second job runs the server for 10 secs and then quits. 