### PR TITLE
Adding unittests to our CircleCI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Install stuff
           command: |
-            sudo apt install -y python3 python3-distutils curl
+            sudo apt update && sudo apt install python3 python3-distutils curl -y
             curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
             #export PATH=$HOME/.poetry/bin:$PATH
             source $HOME/.poetry/env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,23 @@ workflows:
     # Inside the workflow, you define the jobs you want to run. 
     # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
     jobs:
+      - build-from-scratch
       - build-and-test
       - trial-run
 
 jobs:
+  build-from-scratch:
+    docker:
+      - image: cimg/base:2021.04
+    steps:
+      - checkout
+      - run:
+          name: Install stuff
+          command: |
+            sudo apt install -y python curl
+            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+            poetry install
+            poetry run python manage.py test
   build-and-test:
     docker:
       - image: cimg/python:3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           name: Install stuff
           command: |
             sudo apt install -y python3 curl
-            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
             poetry install
             poetry run python manage.py test
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
           command: |
             sudo apt install -y python3 curl
             curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+            export PATH=$HOME/.poetry/bin:$PATH
             poetry install
             poetry run python manage.py test
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ workflows:
       - trial-run
 
 jobs:
-  build-from-scratch:
+  build-from-scratch:  # This job illustrates what is required to get TeamGroove running from a relatively minimal system.
     docker:
       - image: cimg/base:2021.04
     steps:
@@ -25,12 +25,20 @@ jobs:
       - run:
           name: Install stuff
           command: |
-            sudo apt update && sudo apt install python3 python3-distutils curl -y
+            # Use apt update to ensure that apt finds the packages we want to install
+            sudo apt update
+            sudo apt install python3 python3-distutils curl -y
+            # This is the recommended way to install poetry, from https://python-poetry.org/docs/.
             curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-            #export PATH=$HOME/.poetry/bin:$PATH
+            # Use this script installed by the above line to modify the $PATH so poetry works properly.
             source $HOME/.poetry/env
+            # Now set up the packages required by the pyproject.toml file.
             poetry install
+            # Do we have a working installation? Try running the unit tests.
+            mkdir -p test-results
             poetry run python manage.py test
+      - store_test_results:
+          path: test-results
   build-and-test:
     docker:
       - image: cimg/python:3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
   python: circleci/python@1.2
 
 workflows:
-  sample:  # This is the name of the workflow, feel free to change it to better match your workflow.
+  mainflow:  # This is the name of the workflow, feel free to change it to better match your workflow.
     # Inside the workflow, you define the jobs you want to run. 
     # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Install stuff
           command: |
-            sudo apt install -y python curl
+            sudo apt install -y python3 curl
             curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
             poetry install
             poetry run python manage.py test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,10 @@ jobs:
       - run:
           name: Install stuff
           command: |
-            sudo apt install -y python3 curl
+            sudo apt install -y python3 python3-distutils curl
             curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-            export PATH=$HOME/.poetry/bin:$PATH
+            #export PATH=$HOME/.poetry/bin:$PATH
+            source $HOME/.poetry/env
             poetry install
             poetry run python manage.py test
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,10 @@ jobs:
           name: Run tests
           # This assumes pytest is installed via the install-package step above
           command: |
+            mkdir -p test-results
             poetry run python manage.py test
+      - store_test_results:
+          path: test-results
   trial-run:
     docker:
       - image: cimg/python:3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requests = "^2.25.1"
 spotipy = "^2.18"
 Django = "^3.1.7"
 django-environ = "^0.4.5"
+unittest-xml-reporting = "^3.0.4"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.6.0"

--- a/team_groove/settings/base.py
+++ b/team_groove/settings/base.py
@@ -24,6 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # From https://pypi.org/project/unittest-xml-reporting/, a recipe for
 # getting Django to output XML results.
 TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
+TEST_OUTPUT_DIR = 'test-results'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/

--- a/team_groove/settings/base.py
+++ b/team_groove/settings/base.py
@@ -21,6 +21,9 @@ CACHES_FOLDER.mkdir(parents=True, exist_ok=True)
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# From https://pypi.org/project/unittest-xml-reporting/, a recipe for
+# getting Django to output XML results.
+TEST_RUNNER = 'xmlrunner.extra.djangotestrunner.XMLTestRunner'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/

--- a/users/tests.py
+++ b/users/tests.py
@@ -165,7 +165,7 @@ class UsersManagersTests(TestCase):
     def test_password_too_long(self):
         data = {
             "email": "test_maximum_length_password@example.com",
-            "password1": "betterpassword" * 199,
+            "password1": "betterpassword" * 100,
             "password2": "betterpassword" * 100,
         }
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -165,7 +165,7 @@ class UsersManagersTests(TestCase):
     def test_password_too_long(self):
         data = {
             "email": "test_maximum_length_password@example.com",
-            "password1": "betterpassword" * 100,
+            "password1": "betterpassword" * 199,
             "password2": "betterpassword" * 100,
         }
 


### PR DESCRIPTION
We had to experiment quite a lot to get this working. The trick was to install a custom test-runner for Django - our key reference was this page https://pypi.org/project/unittest-xml-reporting/. Once we got that working locally, we spent the rest of the time trying to configure the `.circleci/config.yaml` file to recognise the test results and display in the appropriate section.

We also added a CircleCI "job" for building TeamGroove from scratch. This was mainly a first step towards being about to create our own base image.