### PR TITLE
Fix for forward slash in playlist

### DIFF
--- a/room/views.py
+++ b/room/views.py
@@ -90,7 +90,7 @@ def send_invitation(to_email, code, room):
     
     subject = 'Invitation to use TeamGroove'
     text_content = f'Invitation to use TeamGroove service. Your code is: {code}' 
-    html_content = render_to_string('email_invitation.html', {'code': code, 'room': room, 'accept_url': accept_url})
+    html_content = render_to_string('email_invitation.html', {'invitation_code': code, 'room': room, 'accept_url': accept_url})
 
     msg = EmailMultiAlternatives(subject, text_content, from_email, [to_email])
     msg.attach_alternative(html_content, 'text/html')

--- a/spotify/views.py
+++ b/spotify/views.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 import spotipy
 import os
+import json
 
 from .models import Playlist
 from room.models import Room
@@ -43,7 +44,7 @@ def authorize_with_spotify(request, spotify_code=None):
     return render(request, 'user_playlists.html', context)
 
 @login_required
-def user_playlist_tracks(request, playlist_id, playlist_name):
+def user_playlist_tracks(request, playlist_id):
     cache_handler = spotipy.cache_handler.CacheFileHandler(cache_path=session_cache_path(request))
     auth_manager = spotipy.oauth2.SpotifyOAuth(cache_handler=cache_handler)
 
@@ -51,6 +52,9 @@ def user_playlist_tracks(request, playlist_id, playlist_name):
     user_playlist_tracks = spotify.playlist_items(playlist_id,
                                                     offset=0,
                                                     fields='items.track.id, items.track.name')
+    
+    results = spotify.playlist(playlist_id)
+    playlist_name = results['name']
     
     list_of_track_ids = []
 
@@ -80,8 +84,19 @@ def user_playlist_tracks(request, playlist_id, playlist_name):
         return render(request, 'user_playlist_tracks.html', context)
 
 @login_required
-def add_playlist_to_room(request, playlist_id, playlist_name):
+def add_playlist_to_room(request, playlist_id):
     room = get_object_or_404(Room, pk=request.user.active_room_id, created_by=request.user, status=Room.ACTIVE, members__in=[request.user])
+
+    cache_handler = spotipy.cache_handler.CacheFileHandler(cache_path=session_cache_path(request))
+    auth_manager = spotipy.oauth2.SpotifyOAuth(cache_handler=cache_handler)
+
+    spotify = spotipy.Spotify(auth_manager=auth_manager)
+    user_playlist_tracks = spotify.playlist_items(playlist_id,
+                                                    offset=0,
+                                                    fields='items.track.id, items.track.name')
+    
+    results = spotify.playlist(playlist_id)
+    playlist_name = results['name']
 
     playlist = Playlist.objects.create(room=room, created_by=request.user, playlist_id=playlist_id, playlist_name=playlist_name)
     # Need to add the tracks from the playlist to our db here so we can let people vote on them later?

--- a/spotify/views.py
+++ b/spotify/views.py
@@ -5,12 +5,9 @@ from django.contrib import messages
 from django.conf import settings
 
 import spotipy
-import os
-import json
 
 from .models import Playlist
 from room.models import Room
-
 
 
 def session_cache_path(request):

--- a/team_groove/templates/user_playlist_tracks.html
+++ b/team_groove/templates/user_playlist_tracks.html
@@ -9,7 +9,7 @@
     {% for i in track_name_artist %}
         <a href="#" class="list-group-item list-group-item-action">{{ i }}</a>
     {% endfor %}
-    <a href="{% url 'add_playlist_to_room' playlist_id playlist_name %}" class="btn btn-success"> Add this Playlist to Your Groove Room</a>
+    <a href="{% url 'add_playlist_to_room' playlist_id %}" class="btn btn-success"> Add this Playlist to Your Groove Room</a>
 </div>        
 
 {% endblock %}

--- a/team_groove/templates/user_playlists.html
+++ b/team_groove/templates/user_playlists.html
@@ -8,7 +8,7 @@
 <div class="list-group">
     {% for playlist in current_user_playlists.items %}          
         <a href="#" class="list-group-item list-group-item-action">{{ playlist.name }}</a>
-        <a href="{% url 'user_playlist_tracks' playlist.id playlist.name %}" class="btn btn-success"> View Your Tracks</a>
+        <a href="{% url 'user_playlist_tracks' playlist.id  %}" class="btn btn-success"> View Your Tracks</a>
     {% endfor %}
 </div>
 

--- a/team_groove/urls.py
+++ b/team_groove/urls.py
@@ -38,8 +38,8 @@ urlpatterns = [
 
     path('spotify/authorize_with_spotify/<spotify_code>', authorize_with_spotify, name='authorize_with_spotify'),
     path('spotify/authorize_with_spotify/', authorize_with_spotify, name='authorize_with_spotify'),
-    path('spotify/user_playlist_tracks/<playlist_id>/<playlist_name>', user_playlist_tracks, name='user_playlist_tracks'),
-    path('spotify/add_playlist_to_room/<playlist_id>/<playlist_name>', add_playlist_to_room, name='add_playlist_to_room'),
+    path('spotify/user_playlist_tracks/<playlist_id>/', user_playlist_tracks, name='user_playlist_tracks'),
+    path('spotify/add_playlist_to_room/<playlist_id>/', add_playlist_to_room, name='add_playlist_to_room'),
     
     
 


### PR DESCRIPTION
Changed the existing Spotify Views function arguments so they only use playlist_id and not playlist_name and playlist_id. Updated urls.py so it only uses playlist_id so we should be able to handle forward slashes in playlist names from now on.