### PR TITLE
Fix incorrect syntax detection by VS Code

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,3 +1,9 @@
+#!/bin/sh
+# This include-script is only to be sourced (.) by other shell scripts. The
+# initial #!/bin/sh is included to force VS Code to correctly perform syntax
+# detection - otherwise it incorrectly detects Python and attempts to make 
+# invalid recommendations.
+
 DJANGO_SETTINGS_MODULE="team_groove.settings.development"
 
 # You can generate a local SECRET_KEY using the Python REPL


### PR DESCRIPTION
VS Code incorrectly detects the syntax of `env.example` - and continues to incorrectly classify it when it is moved to `.env`. By inserting a `#!/bin/sh` line at the start, the detection is nudged in the correct direction. 

Notes
 - We suspect the problem is that VS Code's syntax detection is heuristic, guided by machine learning, and occasionally incorrectly classifies files; see https://visualstudiomagazine.com/articles/2021/09/07/vs-code-aug21.aspx
 - This is an include-script, so adding a shebang interpreter directive is not good practice. However, in this case, active harm was being done by the misclassification. This was the simplest action that reliably corrects the misclassification.
 - A good question is whether the shebang directive should use /bin/bash or /bin/zsh. Since /bin/sh is the common basis of the two shells that project members are using, I have chosen /bin/sh and the least misleading.