### PR TITLE
Cleanup grooveboard, change display to rows, not columns

### DIFF
--- a/team_groove/templates/base.html
+++ b/team_groove/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
-    <title>TeamGroove</title>
+    <title>{% block title %}TeamGroove{% endblock %}</title>
 
     <!-- Bootstrap -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">

--- a/team_groove/templates/grooveboard.html
+++ b/team_groove/templates/grooveboard.html
@@ -39,17 +39,25 @@
     <hr>
 {% endif %}
 
+<div class="col-md-12 d-flex">
+    <div class="card mb-2 flex-fill">
+            <a href="{% url 'add_room' %}" class="btn btn-info btn-block"><i class="fa fa-users" aria-hidden="true"></i>  Create a New Room</a>
+    </div>
+</div>
+
 <div class="container-fluid">
     <div class="row">
-        <div class="col-md-4 d-flex">
+        <div class="col-md-12 d-flex">
             <div class="card mb-2 flex-fill">
                 <div class="card-header">
                     <h5>Current Active Room --></h5>
                 </div>
             </div>
         </div>
+    </div>
+    <div class="row">
         {% if active_room %}
-            <div class="col-md-4 d-flex">
+            <div class="col-md-12 d-flex">
                 <div class="card mb-2 flex-fill">
                     <div class="card-header">
                         <h5>{{ active_room.title }}</h5>
@@ -71,18 +79,6 @@
                 </div>
             </div>
         {% endif %}
-        <div class="col-md-4 d-flex">
-            <div class="card mb-2 flex-fill">
-                <div class="card-header">
-                    <h5>Create a New Room</h5>
-                </div>
-                <div class="card-body">
-                    <h5 class="card-title"></h5>
-                    <p class="card-text"></p>
-                </div>
-                <a href="{% url 'add_room' %}" class="btn btn-info btn-block"><i class="fa fa-users" aria-hidden="true"></i>  Create a New Room</a>
-            </div>
-        </div>
     </div>
 </div>
 <hr>


### PR DESCRIPTION
Moved 'Create a New Room' button to the top of the /grooveboard page in grooveboard.html

Changed bootstrap columns to fit container and display as whole row in grooveboard.html

Updated base.html, adding jinja block for title, allowing individual pages to have custom titles